### PR TITLE
Improve plugin example a bit

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -11,20 +11,20 @@ For example, here is a basic plugin that will log a message every time a vex is 
 ```javascript
 var myFirstPlugin = function (vex) {
     return {
-        open: function (options) {
+        name : 'helloWorld',
+        open : function (options) {
             console.log('you opened a vex with a plugin!')
             return vex.open(options)
         }
     }
 }
 
-myFirstPlugin.name = 'myFirstPlugin'
 ```
 
 Then, register your plugin with vex:
 
 ```javascript
 vex.registerPlugin(myFirstPlugin)
-vex.myFirstPlugin.open('Hello!') // logs 'you opened a vex with a plugin!'
+vex.helloWorld.open('Hello!') // logs 'you opened a vex with a plugin!'
 // also opens a vex!
 ```


### PR DESCRIPTION
1. Declare the `name` of the plugin along with the other plugin methods to keep it self contained.
2. Use a different plugin-name and object-name for the plugin to clarify the example.
